### PR TITLE
Fixed tiny bug in multipart POST.

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -214,7 +214,7 @@ object Http {
 
        parts.foreach { part =>
          out.writeBytes(Pref + Boundary + CrLf)
-         out.writeBytes("Content-Disposition: form-data; name=\"" + part.name + "\"; filename=\"" + part.name + "\"" + CrLf)
+         out.writeBytes("Content-Disposition: form-data; name=\"" + part.name + "\"; filename=\"" + part.filename + "\"" + CrLf)
          out.writeBytes("Content-Type: " + part.mime + CrLf + CrLf)
 
          out.write(part.data)


### PR DESCRIPTION
Check me if I’m wrong, but it seems that the method for multipart POST accidentally set the 'filename' parameter to the part’s 'name', rather than 'filename'.
