### PR TITLE
Adding overloaded proxy method to allow for SOCKS proxy usage

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -96,7 +96,7 @@ object Http {
     }
 
     def proxy(host: String, port: Int): Request = proxy(host, port, Proxy.Type.HTTP)
-	def proxy(host: String, port: Int, proxyType: Proxy.Type): Request = copy(proxy = new Proxy(proxyType, new InetSocketAddress(host, port)))
+    def proxy(host: String, port: Int, proxyType: Proxy.Type): Request = copy(proxy = new Proxy(proxyType, new InetSocketAddress(host, port)))
 
     def charset(cs: String): Request = copy(charset = cs)
 


### PR DESCRIPTION
I needed a way to utilize a SOCKS proxy with an HTTP request. I created an overloaded method to pass in the type.
