### PR TITLE
Fixes NoSuchMethodException

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -292,10 +292,10 @@ object Http {
   val setFixedLengthStreamingMode: (HttpURLConnection, Long) => Unit = {
     val connClass = classOf[HttpURLConnection]
     val (isLong, theMethod) = try {
-      true -> connClass.getDeclaredMethod("setFixedLengthStreamingMode", classOf[Long])
+      true -> connClass.getDeclaredMethod("setFixedLengthStreamingMode", java.lang.Long.TYPE)
     } catch {
       case e: NoSuchMethodException =>
-        false -> connClass.getDeclaredMethod("setFixedLengthStreamingMode", classOf[Int])
+        false -> connClass.getDeclaredMethod("setFixedLengthStreamingMode", java.lang.Integer.TYPE)
     }
     (conn, length) => 
       if (isLong) {


### PR DESCRIPTION
```
java.lang.NoSuchMethodException: java.net.HttpURLConnection.setFixedLengthStreamingMode(scala.Long)
    at java.lang.Class.getDeclaredMethod(Class.java:2004)
    at scalaj.http.Http$.<init>(Http.scala:294)
    at scalaj.http.Http$.<clinit>(Http.scala)
    at com.zaneli.escalade.hipchat.HttpExecutor$class.httpExecute(ClientBase.scala:65)
    at com.zaneli.escalade.hipchat.Rooms.httpExecute(Rooms.scala:11)
    at com.zaneli.escalade.hipchat.Rooms$list$$anonfun$$lessinit$greater$4.apply(Rooms.scala:75)
    at com.zaneli.escalade.hipchat.Rooms$list$$anonfun$$lessinit$greater$4.apply(Rooms.scala:75)
    at com.zaneli.escalade.hipchat.ClientBase.execute(ClientBase.scala:22)
    at com.zaneli.escalade.hipchat.AuthClientBase.execute(ClientBase.scala:44)
    at com.zaneli.escalade.hipchat.Rooms$list$.call(Rooms.scala:82)
    at dataxu.rt.metrics.routermonitor.testing$delayedInit$body.apply(testing.scala:6)
    at scala.Function0$class.apply$mcV$sp(Function0.scala:40)
    at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:12)
    at scala.App$$anonfun$main$1.apply(App.scala:71)
    at scala.App$$anonfun$main$1.apply(App.scala:71)
    at scala.collection.immutable.List.foreach(List.scala:318)
    at scala.collection.generic.TraversableForwarder$class.foreach(TraversableForwarder.scala:32)
    at scala.App$class.main(App.scala:71)
    at dataxu.rt.metrics.routermonitor.testing$.main(testing.scala:3)
    at dataxu.rt.metrics.routermonitor.testing.main(testing.scala)
```

Env:

```
$ java -version
java version "1.7.0_45"
Java(TM) SE Runtime Environment (build 1.7.0_45-b18)
Java HotSpot(TM) 64-Bit Server VM (build 24.45-b08, mixed mode)

$ scala -version
Scala code runner version 2.11.1 -- Copyright 2002-2013, LAMP/EPFL
```
