### PR TITLE
Fix npe for request

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -313,7 +313,12 @@ case class HttpRequest(
     val encoding: Option[String] = headers.get("Content-Encoding")
     val body: T = {
       val theStream = if (compress && encoding.exists(_.equalsIgnoreCase("gzip"))) {
-        new GZIPInputStream(inputStream)
+        try {
+          new GZIPInputStream(inputStream)
+          } catch {
+            case x: java.io.EOFException => inputStream
+          }
+        
       } else if(compress && encoding.exists(_.equalsIgnoreCase("deflate"))) {
         new InflaterInputStream(inputStream)
       } else inputStream

--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -312,13 +312,8 @@ case class HttpRequest(
     val headers: Map[String, String] = getResponseHeaders(conn)
     val encoding: Option[String] = headers.get("Content-Encoding")
     val body: T = {
-      val theStream = if (compress && encoding.exists(_.equalsIgnoreCase("gzip"))) {
-        try {
-          new GZIPInputStream(inputStream)
-          } catch {
-            case x: java.io.EOFException => inputStream
-          }
-        
+      val theStream = if (compress && encoding.exists(_.equalsIgnoreCase("gzip")) && inputStream.available() != 0) {
+        new GZIPInputStream(inputStream)
       } else if(compress && encoding.exists(_.equalsIgnoreCase("deflate"))) {
         new InflaterInputStream(inputStream)
       } else inputStream

--- a/src/test/scala/scalaj/http/HttpBinTest.scala
+++ b/src/test/scala/scalaj/http/HttpBinTest.scala
@@ -29,6 +29,12 @@ class HttpBinTest {
     assertEquals("{", response.body.substring(0,1))
   }
 
+  @Test 
+  def gzipWithHead {
+    val response = Http("http://httpbin.org/gzip").method("HEAD").asString
+    assertEquals(200, response.code)
+  }
+
   @Test
   def gzipDecodeNoCompress {
     val response = Http("http://httpbin.org/gzip").compress(false).asString


### PR DESCRIPTION
When i want to get "HEAD" request, for example:

```scala
Http("http://google.com").method("HEAD").asString 
```

i got a 
`
java.lang.NullPointerException
	at java.util.zip.InflaterInputStream.<init>(InflaterInputStream.java:83)
	at java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:77)
	at java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:91)
	at scalaj.http.HttpRequest.toResponse(Http.scala:315)
	at scalaj.http.HttpRequest.exec(Http.scala:298)
	at scalaj.http.HttpRequest.execute(Http.scala:269)
	at scalaj.http.HttpRequest.asParams(Http.scala:482)
	at .<init>(<console>:11)
`

If i set a `compres` option as `compress(false)` all ok.

I fixed this error.

