### PR TITLE
Allow not specifying proxy to use Java default proxy (fixes #65)

### DIFF
--- a/src/test/scala/scalaj/http/HttpTest.scala
+++ b/src/test/scala/scalaj/http/HttpTest.scala
@@ -162,13 +162,13 @@ class HttpTest {
     req = req.options(options)
 
     assertEquals("params", params, req.params)
-    assertEquals("proxy", proxy, req.proxy)
+    assertEquals("proxy", proxy, req.proxyConfig.get)
     assertEquals("options", expectedNewOptions, req.options)
 
     req = req.headers(headers)
 
     assertEquals("params", params, req.params)
-    assertEquals("proxy", proxy, req.proxy)
+    assertEquals("proxy", proxy, req.proxyConfig.get)
     assertEquals("options", expectedNewOptions, req.options)
 
   }


### PR DESCRIPTION
This changes the default proxy from "no proxy" to "whatever Java thinks the default proxy is" (which is usually "no proxy"), and thereby fixes #65 .

This is a worthwhile change because it means that apps using this library will work as expected when the standard proxy environment variables are set (`http.proxyHost`, `http.proxyPort`, `http.nonProxyHosts`, and their https equivalents).

The alternative is either manually parsing and respecting those system properties (particularly painful for `http.nonProxyHosts`), or possibly hacks involving calling out to `sun.net.spi.DefaultProxySelector`.

This is a potentially backwards-incompatible change in behaviour for those people who are not explicitly specifying a proxy to scalaj-http but do have the `http.proxyHost` etc system property variables set: their code will now use the proxy. However, that seems like a rare case to me, and the fix is straightforward (explicitly specify `Proxy.NO_PROXY` as a proxy as I wrote in the docs), so I think this should just be something that can be called out in the release notes.

The alternative is uglier in the long term: keep defaulting to "never use a proxy", but allow people to opt in to using the system default proxy. My opinion is that such behaviour would be more confusing to newcomers to the library, and the continuing negative cost from such an approach outweighs the cost of a once-off breakage (as caused by this PR) in my mind.

Finally, I tried to write a test, but gave up because I couldn't come up with one that doesn't fail if the user does need to use proxies when running scalaj-http tests or does have the proxy system property variables set.