### PR TITLE
Fix for Google AppEngine, reflection should be used only for non-official methods

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -37,7 +37,7 @@ object HttpOptions {
 
   val officalHttpMethods = Set("GET", "POST", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE")
   
-  private val methodField: Field = {
+  private lazy val methodField: Field = {
     val m = classOf[HttpURLConnection].getDeclaredField("method")
     m.setAccessible(true)
     m


### PR DESCRIPTION
Fix incompatibility with GAE, now reflection will be only used for non-official methods.
Was failing badly before due to GAE restrictions on using reflection.