### PR TITLE
make PUT equal citizen

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -402,6 +402,19 @@ case class HttpRequest(
     }
   }
 
+  /** Raw data PUT */
+  def put(data: String): HttpRequest = put(data.getBytes(charset))  
+  
+  /** Raw byte data PUT request */
+  def put(data: Array[Byte]): HttpRequest = {
+    val postFunc: HttpConstants.HttpExec = (req, conn) => {
+      conn.setDoOutput(true)
+      conn.connect
+      conn.getOutputStream.write(data)
+    }
+    copy(method="PUT", connectFunc=postFunc)
+  }  
+  
   /** Standard form POST request */
   def postForm: HttpRequest = postForm(Nil)
 


### PR DESCRIPTION
Implements https://github.com/scalaj/scalaj-http/issues/96. I only briefly tested with Scala 2.11 though.

I guess there should be an example on the readme for `PUT` too now, and maybe refactor to eliminate duplication between post and put now. 

Not sure whether implementing form data for `PUT` is on anyone's wish list, and I've not bothered with that.