### PR TITLE
Basic utilities of java.net for easy and direct access of various frequent methods.

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -196,10 +196,6 @@ case class HttpResponse[T](body: T, code: Int, headers: Map[String, IndexedSeq[S
   /** Get the parsed cookies from the "Set-Cookie" header **/
   def cookies: IndexedSeq[HttpCookie] = headerSeq("Set-Cookie").flatMap(HttpCookie.parse(_).asScala)
 
-  /**
-    * This is wrapper over java.net.URL for easy access of basic parameters of a url.
-    */
-
 
 }
 

--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -32,6 +32,7 @@ import javax.net.ssl.HostnameVerifier
 import java.util.zip.{GZIPInputStream, InflaterInputStream}
 import scala.collection.JavaConverters._
 import scala.util.matching.Regex
+import java.net._
 
 /** Helper functions for modifying the underlying HttpURLConnection */
 object HttpOptions {
@@ -194,6 +195,12 @@ case class HttpResponse[T](body: T, code: Int, headers: Map[String, IndexedSeq[S
 
   /** Get the parsed cookies from the "Set-Cookie" header **/
   def cookies: IndexedSeq[HttpCookie] = headerSeq("Set-Cookie").flatMap(HttpCookie.parse(_).asScala)
+
+  /**
+    * This is wrapper over java.net.URL for easy access of basic parameters of a url.
+    */
+
+
 }
 
 /** Immutable builder for creating an http request
@@ -464,6 +471,44 @@ case class HttpRequest(
   def asParamMap: HttpResponse[Map[String, String]] = execute(HttpConstants.readParamMap(_, charset))
   /** Execute this request and parse http body as a querystring containing oauth_token and oauth_token_secret tupple */
   def asToken: HttpResponse[Token] = execute(HttpConstants.readToken)
+
+  private def URI: URL = new URL(url)
+
+  /**
+    * Creating a wrapper over java.net.URL.
+    * This will help in easy access of various frequent utilities of URL.
+    */
+
+  /** Host value*/
+  def getHost: String = URI.getHost
+
+  /** getFile */
+  def getFile: String = URI.getFile
+
+  /** get default port. If port in not defined then it will return 80 as default http port. */
+  def getDefaultPort: Int = URI.getDefaultPort
+
+  /** get the authority component of the URL */
+  def getAuthority: String = URI.getAuthority
+
+
+  def getContent: AnyRef = URI.getContent
+
+  def getPath: String = URI.getPath
+
+  def getPort: Int = URI.getPort
+
+  def getProtocal: String = URI.getProtocol
+
+  def getQuery: String = URI.getQuery
+
+  /** get the reference component of the URL. */
+  def getRef: String = URI.getRef
+
+  def getUserInfo: String = URI.getUserInfo
+
+  def toURI: URI = URI.toURI
+
 }
 
 case object DefaultConnectFunc extends Function2[HttpRequest, HttpURLConnection, Unit] {

--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -491,22 +491,38 @@ case class HttpRequest(
   /** get the authority component of the URL */
   def getAuthority: String = URI.getAuthority
 
-
+  /** get the contents of the URL */
   def getContent: AnyRef = URI.getContent
 
+  /**
+    * get the path component of this URL.
+    * if url = "http://test.com/testapp/test.do?test_id=1&test_name=SS"
+    * then getPath will be "/testapp/test.do"
+    * */
   def getPath: String = URI.getPath
 
+  /**
+    * gets the port number component of the URL. The getPort method returns an integer that is the port number.
+    * If the port is not set, getPort returns -1
+    * */
   def getPort: Int = URI.getPort
 
+  /** get the protocol identifier component of the URL. */
   def getProtocal: String = URI.getProtocol
 
+  /** get query string send
+    * This can be achieved using one of the above query method also.
+    * for example it will return: "test_id=1&test_name=SS" as query string.
+    * */
   def getQuery: String = URI.getQuery
 
   /** get the reference component of the URL. */
   def getRef: String = URI.getRef
 
+  /** get the userInfo part of this URL. */
   def getUserInfo: String = URI.getUserInfo
 
+  /** get a URI equivalent to this URL. */
   def toURI: URI = URI.toURI
 
 }

--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -195,8 +195,6 @@ case class HttpResponse[T](body: T, code: Int, headers: Map[String, IndexedSeq[S
 
   /** Get the parsed cookies from the "Set-Cookie" header **/
   def cookies: IndexedSeq[HttpCookie] = headerSeq("Set-Cookie").flatMap(HttpCookie.parse(_).asScala)
-
-
 }
 
 /** Immutable builder for creating an http request


### PR DESCRIPTION
Adding basic utilities similar to java.net for frequent access of very basic methods.
This includes:

- getHost
- getPort
- getProtocol
- getDefaultPort
- getUserInfo
- getRef
- getFile
- getContent etc. 
For all the methods added, please refer to [link](https://github.com/arglee/scalaj-http/blob/fbb753a7269fff1a6d9a03245346e70ef0299d58/src/main/scala/scalaj/http/Http.scala#L477).