### PR TITLE
Honor explicitly set Content-Type header to support multipart/related

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -551,7 +551,8 @@ case class MultiPartConnectFunc(parts: Seq[MultiPart]) extends Function2[HttpReq
     conn.setDoOutput(true)
     conn.setDoInput(true)
     conn.setUseCaches(false)
-    conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + Boundary)
+    val contentType = req.headers.find(_._1 == "Content-Type").map(_._2).getOrElse("multipart/form-data")
+    conn.setRequestProperty("Content-Type", contentType + "; boundary=" + Boundary)
     conn.setRequestProperty("MIME-Version", "1.0")
 
     // encode params up front for the length calculation


### PR DESCRIPTION
Uploading attachments with multipart to CouchDb requires the
ability to specify ContentType multipart/related.

See:
http://docs.couchdb.org/en/2.1.1/api/document/common.html#creating-multiple-attachments