### PR TITLE
Lazy applying of oauth headers

### DIFF
--- a/src/main/scala/scalaj/http/OAuth.scala
+++ b/src/main/scala/scalaj/http/OAuth.scala
@@ -27,19 +27,17 @@ object OAuth {
   import javax.crypto.SecretKey
   import javax.crypto.spec.SecretKeySpec
   val MAC = "HmacSHA1"
-      
-  def sign(req: HttpRequest, consumer: Token, token: Option[Token], verifier: Option[String]): HttpRequest = {
-    req.option(conn => {
-      val baseParams: Seq[(String,String)] = Seq(
-        ("oauth_timestamp", (System.currentTimeMillis / 1000).toString),
-        ("oauth_nonce", System.currentTimeMillis.toString)
-      )
-      
-      var (oauthParams, signature) = getSig(baseParams, req, consumer, token, verifier)
-      
-      oauthParams +:= ("oauth_signature", signature)
-      conn.setRequestProperty("Authorization", "OAuth " + oauthParams.map(p => p._1 + "=\"" + percentEncode(p._2) +"\"").mkString(","))
-    })
+
+  def sign(req: HttpRequest, connection: HttpURLConnection, consumer: Token, token: Option[Token], verifier: Option[String]): Unit = {
+    val baseParams: Seq[(String,String)] = Seq(
+      ("oauth_timestamp", (System.currentTimeMillis / 1000).toString),
+      ("oauth_nonce", System.currentTimeMillis.toString)
+    )
+
+    var (oauthParams, signature) = getSig(baseParams, req, consumer, token, verifier)
+
+    oauthParams +:= ("oauth_signature", signature)
+    connection.setRequestProperty("Authorization", "OAuth " + oauthParams.map(p => p._1 + "=\"" + percentEncode(p._2) +"\"").mkString(","))
   }
   
   def getSig(baseParams: Seq[(String,String)], req: HttpRequest, consumer: Token, token: Option[Token], verifier: Option[String]): (Seq[(String,String)], String) = {


### PR DESCRIPTION
Related to https://github.com/scalaj/scalaj-http/issues/82

Problem was that `Oauth.sign` added a callback option with a reference to the current parameter state and any paramateras added after that would not be included in the signature. Solved by saving oauth data in `signatureCreds` and apply them just before the request is executed. A better solution would have been to change `HttpOption` to `(HttpRequest, HttpURLConnection) => Unit` - thus allowing that callback to use the latest version of the request in its logic, but the breakage of the API scared me into this solution.