### PR TITLE
Make default User-Agent follow library's version.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,10 @@ libraryDependencies ++= {
   }
 }
 
+enablePlugins(BuildInfoPlugin)
+buildInfoKeys := Seq[BuildInfoKey](version)
+buildInfoPackage := "scalaj.http"
+
 // TODO enable all tests when released jackson-module-scala for Scala 2.13
 sources in Test := {
   val testSources = (sources in Test).value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -793,7 +793,7 @@ class BaseHttp (
   options: Seq[HttpOptions.HttpOption] = HttpConstants.defaultOptions,
   charset: String = HttpConstants.utf8,
   sendBufferSize: Int = 4096,
-  userAgent: String = "scalaj-http/1.0",
+  userAgent: String = s"scalaj-http/${BuildInfo.version}",
   compress: Boolean = true
 ) {
 


### PR DESCRIPTION
This PR addresses https://github.com/scalaj/scalaj-http/issues/159 using `sbt/sbt-buildinfo`.

This change will make default User-Agent `scalaj-http/${library's version}` (e.g `scalaj-http/2.4.0`)

```
scala> import scalaj.http._
import scalaj.http._

scala> Http("http://httpbin.org/user-agent").asString
res0: scalaj.http.HttpResponse[String] =
HttpResponse({
  "user-agent": "scalaj-http/2.4.0"
}
...
```