### PR TITLE
Add explicit null pointer catch block to satisfy GraalVM's implicit exception handling

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -448,6 +448,7 @@ case class HttpRequest(
     try {
       conn.getErrorStream.close
     } catch {
+      case npe: NullPointerException => // ignore
       case e: Exception => //ignore
     }
   }


### PR DESCRIPTION
Related to: https://github.com/oracle/graal/issues/357

GraalVM handles implicit exception checks differently than JVM when compiling native image. This is required to be able to use scalaj-http in command line utils compiled to native applications via GraalVM's native-image utility.