### PR TITLE
fix warning in Scala 2.13. use string interpolation

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -113,7 +113,7 @@ case class HttpStatusException(
   code: Int,
   statusLine: String,
   body: String
-) extends RuntimeException(code + " Error: " + statusLine)
+) extends RuntimeException(s"${code} Error: ${statusLine}")
 
 /** Result of executing a [[scalaj.http.HttpRequest]]
   * @tparam T the body response since it can be parsed directly to things other than String


### PR DESCRIPTION
- https://github.com/scala/scala/commit/15fd2c90747f7dfb3901b8454d78658cd855ea3f
- https://github.com/scala/scala/pull/7201