### PR TITLE
Fix spurious NPE

### DIFF
--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -446,9 +446,10 @@ case class HttpRequest(
       case e: Exception => //ignore
     }
     try {
-      conn.getErrorStream.close
+      if(conn.getErrorStream != null) {
+        conn.getErrorStream.close
+      }
     } catch {
-      case npe: NullPointerException => // ignore
       case e: Exception => //ignore
     }
   }


### PR DESCRIPTION
The current code always calls close on an error stream that is probably null.
This causes issues because:
1) Generating an exception is relatively slow
2) It interferes with automatic exception tracking, leading to false positives (NPEs should generally be an indication of problems)
3) The explicit handling for GraalVM block, which shouldn't be necessary.

Just need to check it before closing it.