### PR TITLE
post and put requests with body served from an inputstream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "scalaj-http"
 
-version := "2.4.1"
+version := "2.4.1-SNAPSHOT"
 
 organization := "org.scalaj"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "scalaj-http"
 
-version := "2.4.1-SNAPSHOT"
+version := "2.4.1"
 
 organization := "org.scalaj"
 

--- a/src/main/scala/scalaj/http/Http.scala
+++ b/src/main/scala/scalaj/http/Http.scala
@@ -20,7 +20,7 @@ import collection.immutable.TreeMap
 import java.lang.reflect.Field
 import java.net.{HttpCookie, HttpURLConnection, InetSocketAddress, Proxy, URL, URLEncoder, URLDecoder}
 import java.io.{DataOutputStream, InputStream, BufferedReader, InputStreamReader, ByteArrayInputStream, 
-  ByteArrayOutputStream}
+  ByteArrayOutputStream, OutputStream}
 import java.security.cert.X509Certificate
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLContext


### PR DESCRIPTION
API methods for creating a `PUT` or `POST` request with a body from an `java.io.InputStream`. This way sending data is supported without loading it into memory first.