### PR TITLE
Move Json object and Jackson dependency to production code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies += {
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9"            % "test"
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9"
 }
 
 enablePlugins(BuildInfoPlugin)

--- a/src/main/scala/scalaj/http/Json.scala
+++ b/src/main/scala/scalaj/http/Json.scala
@@ -1,11 +1,26 @@
 package scalaj.http
 
-import java.io.StringWriter
+/** scalaj.http
+  Copyright 2010 Jonathan Hoffman
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import java.io.StringWriter
 
 object Json {
   private val mapper = new ObjectMapper() with ScalaObjectMapper

--- a/src/main/scala/scalaj/http/Json.scala
+++ b/src/main/scala/scalaj/http/Json.scala
@@ -1,26 +1,11 @@
 package scalaj.http
 
-/** scalaj.http
-  Copyright 2010 Jonathan Hoffman
+import java.io.StringWriter
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
- */
- 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import java.io.StringWriter
 
 object Json {
   private val mapper = new ObjectMapper() with ScalaObjectMapper
@@ -37,4 +22,4 @@ object Json {
     mapper.writeValue(out, obj)
     out.toString
   }
-}   
+}


### PR DESCRIPTION
Once in scala sdk newer versions there is no Json utils anymore and scalaj-http can be a common dependency for those who are looking for a Json parser. This change could be helpfull.